### PR TITLE
Write feature attributes to gltf

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 cmake-build*
 tmp
+.run

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+cmake-build*
+tmp

--- a/nodes.hpp
+++ b/nodes.hpp
@@ -471,6 +471,7 @@ class GLTFWriterNode : public Node {
   bool binary_ = true;
   bool relative_to_center = false;
   std::string CRS_ = "EPSG:4978";
+  std::string feature_id_attribute_;
 
 public:
   using Node::Node;
@@ -479,6 +480,7 @@ public:
     add_vector_input("triangles", typeid(TriangleCollection));
     add_vector_input("normals", typeid(vec3f));
     add_vector_input("feature_type", typeid(std::string));
+    add_poly_input("attributes", {typeid(bool), typeid(int), typeid(float), typeid(std::string), typeid(std::string), typeid(Date), typeid(Time), typeid(DateTime)});
 
     // declare parameters
     add_param(ParamString(CRS_, "CRS", "Coordinate reference system text. Can be EPSG code, WKT definition, etc."));
@@ -488,6 +490,7 @@ public:
     add_param(ParamBool(pretty_print_, "pretty_print", "pretty_print"));
     add_param(ParamBool(binary_, "binary", "binary"));
     add_param(ParamBool(relative_to_center, "relative_to_center", "relative_to_center"));
+    add_param(ParamString(feature_id_attribute_, "feature_id", "The feature attribute to use as the _FEATURE_ID vertex attribute value in the EXT_mesh_features extension. The attribute value must be cast-able to a float. If empty, it will be a sequential ID per feature."));
     // add_param(ParamBool(bag3d_buildings_mode_, "3bag_buildings_mode", "Assume 3dbag building-buildingPart structure"));
     // add_param(ParamString(optimal_lod_value_, "optimal_lod_value", "Pick only this LoD"));
   }

--- a/nodes.hpp
+++ b/nodes.hpp
@@ -472,6 +472,7 @@ class GLTFWriterNode : public Node {
   bool relative_to_center = false;
   std::string CRS_ = "EPSG:4978";
   std::string feature_id_attribute_;
+  std::string metadata_class_name_;
 
 public:
   using Node::Node;
@@ -491,6 +492,7 @@ public:
     add_param(ParamBool(binary_, "binary", "binary"));
     add_param(ParamBool(relative_to_center, "relative_to_center", "relative_to_center"));
     add_param(ParamString(feature_id_attribute_, "feature_id", "The feature attribute to use as the _FEATURE_ID vertex attribute value in the EXT_mesh_features extension. The attribute value must be cast-able to a float. If empty, it will be a sequential ID per feature."));
+    add_param(ParamString(metadata_class_name_, "metadata_class", "The name of the metadata class to create (for EXT_structural_metadata)"));
     // add_param(ParamBool(bag3d_buildings_mode_, "3bag_buildings_mode", "Assume 3dbag building-buildingPart structure"));
     // add_param(ParamString(optimal_lod_value_, "optimal_lod_value", "Pick only this LoD"));
   }

--- a/nodes_cityjson.cpp
+++ b/nodes_cityjson.cpp
@@ -935,25 +935,25 @@ namespace geoflow::nodes::basic3d
               if (jval.is_number_float())
                 attributes.sub_terminal(jname).push_back(jval.get<float>());
               else
-                std::cout<< "inconsistent attribute type for: " << jname << std::endl;
+                std::cout<< "inconsistent attribute type for: " << jname << ". Should be float, but it is " << jval.type_name() << std::endl;
             } else if (attributes.sub_terminal(jname).accepts_type(typeid(int))) {
               // std::cout<< "flt:" << jval.get<float>() << std::endl;
               if (jval.is_number_integer())
                 attributes.sub_terminal(jname).push_back(jval.get<int>());
               else
-                std::cout<< "inconsistent attribute type for: " << jname << std::endl;
+                std::cout<< "inconsistent attribute type for: " << jname << ". Should be integer, but it is " << jval.type_name() << std::endl;
             } else if (attributes.sub_terminal(jname).accepts_type(typeid(bool))) {
               // std::cout<< "flt:" << jval.get<float>() << std::endl;
               if (jval.is_boolean())
                 attributes.sub_terminal(jname).push_back(jval.get<bool>());
               else
-                std::cout<< "inconsistent attribute type for: " << jname << std::endl;
+                std::cout<< "inconsistent attribute type for: " << jname << ". Should be boolean, but it is " << jval.type_name() << std::endl;
             } else if (attributes.sub_terminal(jname).accepts_type(typeid(std::string))) {
               // std::cout<< "flt:" << jval.get<float>() << std::endl;
               if (jval.is_string())
                 attributes.sub_terminal(jname).push_back(jval.get<std::string>());
               else
-                std::cout<< "inconsistent attribute type for: " << jname << std::endl;
+                std::cout<< "inconsistent attribute type for: " << jname << ". Should be string, but it is " << jval.type_name() << std::endl;
             } else {
               attributes.sub_terminal(jname).push_back_any(std::any());
             }

--- a/nodes_cityjson.cpp
+++ b/nodes_cityjson.cpp
@@ -902,8 +902,6 @@ namespace geoflow::nodes::basic3d
             std::cout<< "skipping..." <<std::endl;
             continue;
           }
-          
-          vector_output("feature_type").push_back(ftype);
 
           std::string selected_lod;
           if(lod_filter.count(ftype)) {
@@ -926,67 +924,7 @@ namespace geoflow::nodes::basic3d
           // std::cout<< "CID:" << id << std::endl;
           // std::cout<< "vertex_count:" << cobject[]<< std::endl;
           // get_attributes
-          for(auto& [jname, jval] : cobject["attributes"].items()) {
-            // std::cout << jname <<std::endl;
-            if(!attribute_filter_map.count(jname)) continue;
-
-            if (attributes.sub_terminal(jname).accepts_type(typeid(float))) {
-              if (jval.is_number_float())
-                attributes.sub_terminal(jname).push_back(jval.get<float>());
-              else {
-                std::size_t pos{};
-                try {
-                  const float jval_float{ std::stof(jval.get<std::string>(),
-                                                    &pos) };
-                  attributes.sub_terminal(jname).push_back(jval_float);
-                } catch (std::invalid_argument const& ex) {
-                  std::cout << "could not convert attribute " << jname
-                            << " from " << jval.type_name() << " to float"
-                            << std::endl;
-                } catch (std::out_of_range const& ex) {
-                  std::cout << "attribute value (" << jval.get<std::string>()
-                            << ") of " << jname
-                            << " is out of range for a float" << std::endl;
-                }
-              }
-            } else if (attributes.sub_terminal(jname).accepts_type(
-                         typeid(int))) {
-              if (jval.is_number_integer())
-                attributes.sub_terminal(jname).push_back(jval.get<int>());
-              else {
-                std::size_t pos{};
-                try {
-                  const int jval_int{ std::stoi(jval.get<std::string>(),
-                                                &pos) };
-                  attributes.sub_terminal(jname).push_back(jval_int);
-                } catch (std::invalid_argument const& ex) {
-                  std::cout << "could not convert attribute " << jname
-                            << " from " << jval.type_name() << " to int"
-                            << std::endl;
-                } catch (std::out_of_range const& ex) {
-                  std::cout << "attribute value (" << jval.get<std::string>()
-                            << ") of " << jname << " is out of range for an int"
-                            << std::endl;
-                }
-              }
-            } else if (attributes.sub_terminal(jname).accepts_type(
-                         typeid(bool))) {
-              if (jval.is_boolean())
-                attributes.sub_terminal(jname).push_back(jval.get<bool>());
-              else {
-                bool b;
-                std::istringstream(jval.get<std::string>()) >> std::boolalpha >>
-                  b;
-                attributes.sub_terminal(jname).push_back(b);
-              }
-            } else if (attributes.sub_terminal(jname).accepts_type(
-                         typeid(std::string))) {
-              attributes.sub_terminal(jname).push_back(jval.get<std::string>());
-            } else {
-              attributes.sub_terminal(jname).push_back_any(std::any());
-            }
-          }
-          
+          bool pushed_geometry = false; 
           for (const auto& geom : cobject["geometry"]) {
             // get geometry for highest lod
             std::cout << "found geom with lod "<< geom["lod"] << std::endl;
@@ -1009,6 +947,7 @@ namespace geoflow::nodes::basic3d
                 mesh.push_polygon(ring, 2);
               }
               meshes.push_back(mesh);
+              pushed_geometry = true;
             } else if (geom["type"] == "MultiSurface") {
               Mesh mesh;
               // get faces of exterior shell
@@ -1027,11 +966,67 @@ namespace geoflow::nodes::basic3d
                 mesh.push_polygon(ring, 2);
               }
               meshes.push_back(mesh);
+              pushed_geometry = true;
             } else {
               throw(gfIOError("Unsupported geometry type"));
             }
           }
-          
+          if (pushed_geometry) {
+            vector_output("feature_type").push_back(ftype);
+            for(auto& [name, attribute] : attributes.sub_terminals()) {
+              if(!cobject["attributes"].count(name)) {
+                attribute->push_back_any(std::any());
+                continue;
+              }
+              auto& jval = cobject["attributes"][name];
+              if (attribute->accepts_type( typeid(float)) ) {
+                if (jval.is_number_float())
+                  attribute->push_back(jval.get<float>());
+                else {
+                  try {
+                    const float jval_float{ std::stof(jval.get<std::string>()) };
+                    attribute->push_back(jval_float);
+                  } catch (std::invalid_argument const& ex) {
+                    std::cout << "could not convert attribute " << name
+                              << " from " << jval.type_name() << " to float"
+                              << std::endl;
+                  } catch (std::out_of_range const& ex) {
+                    std::cout << "attribute value (" << jval.get<std::string>()
+                              << ") of " << name
+                              << " is out of range for a float" << std::endl;
+                  }
+                }
+              } else if (attribute->accepts_type( typeid(int) )) {
+                if (jval.is_number_integer())
+                  attribute->push_back(jval.get<int>());
+                else {
+                  try {
+                    const int jval_int{ std::stoi(jval.get<std::string>()) };
+                    attribute->push_back(jval_int);
+                  } catch (std::invalid_argument const& ex) {
+                    std::cout << "could not convert attribute " << name
+                              << " from " << jval.type_name() << " to int"
+                              << std::endl;
+                  } catch (std::out_of_range const& ex) {
+                    std::cout << "attribute value (" << jval.get<std::string>()
+                              << ") of " << name << " is out of range for an int"
+                              << std::endl;
+                  }
+                }
+              } else if (attribute->accepts_type( typeid(bool) )) {
+                if (jval.is_boolean())
+                  attribute->push_back(jval.get<bool>());
+                else {
+                  bool b;
+                  std::istringstream(jval.get<std::string>()) >> std::boolalpha >>
+                    b;
+                  attribute->push_back(b);
+                }
+              } else if (attribute->accepts_type( typeid(std::string) )) {
+                attribute->push_back(jval.get<std::string>());
+              }
+            }
+          }
         }
       }
     }

--- a/nodes_cityjson.cpp
+++ b/nodes_cityjson.cpp
@@ -929,31 +929,59 @@ namespace geoflow::nodes::basic3d
           for(auto& [jname, jval] : cobject["attributes"].items()) {
             // std::cout << jname <<std::endl;
             if(!attribute_filter_map.count(jname)) continue;
-            
+
             if (attributes.sub_terminal(jname).accepts_type(typeid(float))) {
-              // std::cout<< "flt:" << jval.get<float>() << std::endl;
               if (jval.is_number_float())
                 attributes.sub_terminal(jname).push_back(jval.get<float>());
-              else
-                std::cout<< "inconsistent attribute type for: " << jname << ". Should be float, but it is " << jval.type_name() << std::endl;
-            } else if (attributes.sub_terminal(jname).accepts_type(typeid(int))) {
-              // std::cout<< "flt:" << jval.get<float>() << std::endl;
+              else {
+                std::size_t pos{};
+                try {
+                  const float jval_float{ std::stof(jval.get<std::string>(),
+                                                    &pos) };
+                  attributes.sub_terminal(jname).push_back(jval_float);
+                } catch (std::invalid_argument const& ex) {
+                  std::cout << "could not convert attribute " << jname
+                            << " from " << jval.type_name() << " to float"
+                            << std::endl;
+                } catch (std::out_of_range const& ex) {
+                  std::cout << "attribute value (" << jval.get<std::string>()
+                            << ") of " << jname
+                            << " is out of range for a float" << std::endl;
+                }
+              }
+            } else if (attributes.sub_terminal(jname).accepts_type(
+                         typeid(int))) {
               if (jval.is_number_integer())
                 attributes.sub_terminal(jname).push_back(jval.get<int>());
-              else
-                std::cout<< "inconsistent attribute type for: " << jname << ". Should be integer, but it is " << jval.type_name() << std::endl;
-            } else if (attributes.sub_terminal(jname).accepts_type(typeid(bool))) {
-              // std::cout<< "flt:" << jval.get<float>() << std::endl;
+              else {
+                std::size_t pos{};
+                try {
+                  const int jval_int{ std::stoi(jval.get<std::string>(),
+                                                &pos) };
+                  attributes.sub_terminal(jname).push_back(jval_int);
+                } catch (std::invalid_argument const& ex) {
+                  std::cout << "could not convert attribute " << jname
+                            << " from " << jval.type_name() << " to int"
+                            << std::endl;
+                } catch (std::out_of_range const& ex) {
+                  std::cout << "attribute value (" << jval.get<std::string>()
+                            << ") of " << jname << " is out of range for an int"
+                            << std::endl;
+                }
+              }
+            } else if (attributes.sub_terminal(jname).accepts_type(
+                         typeid(bool))) {
               if (jval.is_boolean())
                 attributes.sub_terminal(jname).push_back(jval.get<bool>());
-              else
-                std::cout<< "inconsistent attribute type for: " << jname << ". Should be boolean, but it is " << jval.type_name() << std::endl;
-            } else if (attributes.sub_terminal(jname).accepts_type(typeid(std::string))) {
-              // std::cout<< "flt:" << jval.get<float>() << std::endl;
-              if (jval.is_string())
-                attributes.sub_terminal(jname).push_back(jval.get<std::string>());
-              else
-                std::cout<< "inconsistent attribute type for: " << jname << ". Should be string, but it is " << jval.type_name() << std::endl;
+              else {
+                bool b;
+                std::istringstream(jval.get<std::string>()) >> std::boolalpha >>
+                  b;
+                attributes.sub_terminal(jname).push_back(b);
+              }
+            } else if (attributes.sub_terminal(jname).accepts_type(
+                         typeid(std::string))) {
+              attributes.sub_terminal(jname).push_back(jval.get<std::string>());
             } else {
               attributes.sub_terminal(jname).push_back_any(std::any());
             }

--- a/nodes_gltf.cpp
+++ b/nodes_gltf.cpp
@@ -126,7 +126,7 @@ namespace geoflow::nodes::basic3d
     create_materials(model);
 
     std::vector<arr6f> vertex_vec; // position + normal
-    std::vector<unsigned> feature_id_vec; // feature id vertex attribute
+    std::vector<float> feature_id_vec; // feature id vertex attribute
     std::vector<unsigned> index_vec;
     std::vector<TCInfo> info_vec;
     unsigned v_offset = 0;

--- a/nodes_gltf.cpp
+++ b/nodes_gltf.cpp
@@ -19,6 +19,7 @@
 #define STB_IMAGE_IMPLEMENTATION
 #define STB_IMAGE_WRITE_IMPLEMENTATION
 #include "tiny_gltf.h"
+#include <nlohmann/json.hpp>
 
 namespace geoflow::nodes::basic3d
 {
@@ -64,6 +65,36 @@ namespace geoflow::nodes::basic3d
     GenericCityObject.pbrMetallicRoughness.baseColorFactor = { 0.909, 0.188, 0.827, 1.0 };
     model.materials.push_back(GenericCityObject);
   };
+
+  tinygltf::Value create_ext_mesh_features(int featureCount,
+                                                  int attribute,
+                                                  int propertyTable)
+  { // EXT_mesh_features
+    // We only have one feature ID set. This feature ID set releates the
+    // feature ID vertex attribute to the feature attribute, thus each for a
+    // given feature (eg CityObject), we have one feature ID and this added to
+    // each vertex (this is the vertex attribute).
+    tinygltf::Value::Object featureId_set;
+    // The number of unique features that are identified WITHIN ONE array of
+    // feature ID-s for ONE mesh primitive. Thus, if we are assigning attributes
+    // to a whole CityObject for instance, which is represented by one mesh
+    // primitive, then this value will be 1.
+    // If we need to distinguish between semantic surfaces, then this value is
+    // the number of distinct surfaces within the mesh primitive.
+    featureId_set["featureCount"] = tinygltf::Value(featureCount);
+    // The value of "attribute" value is the index of the standard gltf
+    // accessor that refers to the actual feature ID-s in the buffer, for the
+    // current feature. The _FEATURE_ID_n semantic has the same value for 'n'
+    // as the "attribute", thus the index of the accessor.
+    featureId_set[ "attribute"] = tinygltf::Value(attribute);
+    // This feature ID set is associated with the propertyTable at the index.
+    featureId_set[ "propertyTable"] = tinygltf::Value(propertyTable);
+    tinygltf::Value::Array featureId_sets;
+    featureId_sets.emplace_back(featureId_set);
+    tinygltf::Value::Object ext_mesh_features_object;
+    ext_mesh_features_object["featureIds"] = tinygltf::Value(featureId_sets);
+    return tinygltf::Value(ext_mesh_features_object);
+  }
 
   unsigned get_material_id(const std::string type) {
     // std::cout << "assigning material for " << type << std::endl;
@@ -128,35 +159,52 @@ namespace geoflow::nodes::basic3d
     std::vector<arr6f> vertex_vec; // position + normal
     std::vector<float> feature_id_vec; // feature id vertex attribute
     std::vector<unsigned> index_vec;
-    std::vector<TCInfo> info_vec;
-    unsigned v_offset = 0;
-    unsigned i_offset = 0;
-    float feature_id = 0.0; // It's a float, because glTF accessors do not support UNSIGNED_INT types for 32-bit integers in vertex attributes.
+    std::vector<TCInfo>   info_vec;
+    // TODO: we need to protect against invalid values, eg. bouwjaar=-1 or so
+    // TODO: these three vectors are hardcoded for now, for testing. Normally,
+    //  we would want to construct these vectors dynamically, based on what
+    //  attribute inputs we get.
+    std::vector<unsigned> attr_1_vec; // objectid
+    // We store the string attributes in a contiguous vector of char-s. This
+    // makes it simpler to calculate its size and copy it to the buffer.
+    std::vector<char>          attr_2_vec; // bagpandid
+    unsigned long              string_offset            = 0;
+    std::vector<unsigned long> attr_2_string_offset_vec = {
+      string_offset,
+    }; // offsets for strings
+       // https://github.com/CesiumGS/3d-tiles/tree/main/specification/Metadata#strings
+    std::vector<unsigned short> attr_3_vec; // bouwjaar
+    unsigned                    v_offset = 0;
+    unsigned                    i_offset = 0;
+    // It's a float, because glTF accessors do not support UNSIGNED_INT types
+    // for 32-bit integers in vertex attributes. There is UNSIGNED_SHORT, but
+    // probably there could be more than ~65k individual features that we need
+    // to identify in one gltf file.
+    float feature_id = 0.0;
     manager.set_rev_crs_transform(manager.substitute_globals(CRS_).c_str());
 
     // determine approximate centerpoint
     // if(relative_to_center) {
-      Box global_bbox;
-      for(unsigned i=0; i< triangle_collections_inp.size(); ++i) {
-        if (!triangle_collections_inp.get_data_vec()[i].has_value()) continue;
-        auto tc = triangle_collections_inp.get<TriangleCollection>(i);
-        if (tc.vertex_count() == 0)
-          continue;
-        global_bbox.add(
-          manager.coord_transform_rev(tc[0][1])
-        );
-      }
-      arr3f c = global_bbox.center();
+    Box global_bbox;
+    for (unsigned i = 0; i < triangle_collections_inp.size(); ++i) {
+      if (!triangle_collections_inp.get_data_vec()[i].has_value())
+        continue;
+      auto tc = triangle_collections_inp.get<TriangleCollection>(i);
+      if (tc.vertex_count() == 0)
+        continue;
+      global_bbox.add(manager.coord_transform_rev(tc[0][1]));
+    }
+    arr3f c = global_bbox.center();
     // }
 
-    for(unsigned i=0; i< triangle_collections_inp.size(); ++i) {
-      if (!triangle_collections_inp.get_data_vec()[i].has_value()) continue;
+    for (unsigned i = 0; i < triangle_collections_inp.size(); ++i) {
+      if (!triangle_collections_inp.get_data_vec()[i].has_value())
+        continue;
       auto tc = triangle_collections_inp.get<TriangleCollection>(i);
       if (tc.vertex_count() == 0)
         continue;
       auto& normals = normals_inp.get<vec3f>(i);
-      
-      
+
       TCInfo inf;
       inf.i_input = i;
       Box positions_box;
@@ -239,6 +287,19 @@ namespace geoflow::nodes::basic3d
         i_offset += i;
       }
       feature_id += 1;
+      // TODO: the feature ID should be selectable (eg it should be the
+      // 'objectid' so that a feature can reference an external object)
+      // add feature attribute values
+      attr_1_vec.push_back(i);
+      attr_3_vec.push_back(9999);
+      // for string attributes, we also need to keep track of the offsets
+      std::string string_attr = "0603100000023033";
+      string_offset += string_attr.size() * sizeof(char);
+      for (auto s : string_attr) {
+        attr_2_vec.emplace_back(s);
+      }
+      attr_2_string_offset_vec.push_back(string_offset);
+
       info_vec.push_back(inf);
     }
     manager.clear_rev_crs_transform();
@@ -252,100 +313,244 @@ namespace geoflow::nodes::basic3d
     auto byteOffset_attributes = index_vec.size() * sizeof(unsigned);
     auto byteOffset_feature_id = index_vec.size()*sizeof(unsigned) + vertex_vec.size()*6*sizeof(float);
 
-    for(unsigned i=0; i< info_vec.size(); ++i) {
-      auto& inf = info_vec[i];
-      auto& ftype = featuretype_inp.get<std::string>(inf.i_input);
+    // Add the Mesh primitives
+    for (unsigned i = 0; i < info_vec.size(); ++i) {
+      auto&                inf   = info_vec[i];
+      auto&                ftype = featuretype_inp.get<std::string>(inf.i_input);
       tinygltf::BufferView bf_attributes;
       tinygltf::BufferView bf_indices;
       tinygltf::BufferView bf_feature_ids;
-      tinygltf::Accessor acc_positions;
-      tinygltf::Accessor acc_normals;
-      tinygltf::Accessor acc_indices;
-      tinygltf::Accessor acc_feature_ids;
-      tinygltf::Primitive primitive;
+      tinygltf::Accessor   acc_positions;
+      tinygltf::Accessor   acc_normals;
+      tinygltf::Accessor   acc_indices;
+      tinygltf::Accessor   acc_feature_ids;
+      tinygltf::Primitive  primitive;
 
-      bf_indices.buffer = 0;
+      bf_indices.buffer     = 0;
       bf_indices.byteOffset = inf.index_offset * sizeof(unsigned);
       bf_indices.byteLength = inf.index_count * sizeof(unsigned);
-      bf_indices.target = TINYGLTF_TARGET_ELEMENT_ARRAY_BUFFER;
-      auto id_bf_indices = model.bufferViews.size();
+      bf_indices.target     = TINYGLTF_TARGET_ELEMENT_ARRAY_BUFFER;
+      auto id_bf_indices    = model.bufferViews.size();
       model.bufferViews.push_back(bf_indices);
 
-      acc_indices.bufferView = id_bf_indices;
-      acc_indices.byteOffset = 0;
-      acc_indices.type = TINYGLTF_TYPE_SCALAR;
+      acc_indices.bufferView    = id_bf_indices;
+      acc_indices.byteOffset    = 0;
+      acc_indices.type          = TINYGLTF_TYPE_SCALAR;
       acc_indices.componentType = TINYGLTF_COMPONENT_TYPE_UNSIGNED_INT;
-      acc_indices.count = inf.index_count;
-      acc_indices.minValues = {inf.index_min};
-      acc_indices.maxValues = {inf.index_max};
+      acc_indices.count         = inf.index_count;
+      // FIXME: "Declared minimum value for this component (-0.7280862927436829) does not match actual minimum (-0.6278660297393799)."
+      acc_indices.minValues     = { inf.index_min };
+      acc_indices.maxValues     = { inf.index_max };
       model.accessors.push_back(acc_indices);
-      primitive.indices = model.accessors.size()-1;
+      primitive.indices = model.accessors.size() - 1;
 
       bf_attributes.buffer = 0;
-      bf_attributes.byteOffset = byteOffset_attributes + inf.vertex_offset * 6 * sizeof(float);
+      bf_attributes.byteOffset =
+        byteOffset_attributes + inf.vertex_offset * 6 * sizeof(float);
       bf_attributes.byteLength = inf.vertex_count * 6 * sizeof(float);
       bf_attributes.byteStride = 6 * sizeof(float);
-      bf_attributes.target = TINYGLTF_TARGET_ARRAY_BUFFER;
-      auto id_bf_attributes = model.bufferViews.size();
+      bf_attributes.target     = TINYGLTF_TARGET_ARRAY_BUFFER;
+      auto id_bf_attributes    = model.bufferViews.size();
       model.bufferViews.push_back(bf_attributes);
 
-      acc_positions.bufferView = id_bf_attributes;
-      acc_positions.byteOffset = 0;
-      acc_positions.type = TINYGLTF_TYPE_VEC3;
+      acc_positions.bufferView    = id_bf_attributes;
+      acc_positions.byteOffset    = 0;
+      acc_positions.type          = TINYGLTF_TYPE_VEC3;
       acc_positions.componentType = TINYGLTF_COMPONENT_TYPE_FLOAT;
-      acc_positions.count = inf.vertex_count;
-      acc_positions.minValues = inf.positions_min;
-      acc_positions.maxValues = inf.positions_max;
+      acc_positions.count         = inf.vertex_count;
+      acc_positions.minValues     = inf.positions_min;
+      acc_positions.maxValues     = inf.positions_max;
       model.accessors.push_back(acc_positions);
-      primitive.attributes["POSITION"] = model.accessors.size()-1;  // The index of the accessor for positions
+      primitive.attributes["POSITION"] =
+        model.accessors.size() - 1; // The index of the accessor for positions
 
-      acc_normals.bufferView = id_bf_attributes;
-      acc_normals.byteOffset = 3 * sizeof(float);
-      acc_normals.type = TINYGLTF_TYPE_VEC3;
+      acc_normals.bufferView    = id_bf_attributes;
+      acc_normals.byteOffset    = 3 * sizeof(float);
+      acc_normals.type          = TINYGLTF_TYPE_VEC3;
       acc_normals.componentType = TINYGLTF_COMPONENT_TYPE_FLOAT;
-      acc_normals.count = inf.vertex_count;
-      acc_normals.minValues = inf.normals_min;
-      acc_normals.maxValues = inf.normals_max;
+      acc_normals.count         = inf.vertex_count;
+      acc_normals.minValues     = inf.normals_min;
+      acc_normals.maxValues     = inf.normals_max;
       model.accessors.push_back(acc_normals);
-      primitive.attributes["NORMAL"] = model.accessors.size()-1;  // The index of the accessor for normals
+      primitive.attributes["NORMAL"] =
+        model.accessors.size() - 1; // The index of the accessor for normals
 
       bf_feature_ids.buffer = 0;
-      bf_feature_ids.byteOffset = byteOffset_feature_id + inf.vertex_offset * sizeof(float);
+      bf_feature_ids.byteOffset =
+        byteOffset_feature_id + inf.vertex_offset * sizeof(float);
       bf_feature_ids.byteLength = inf.vertex_count * sizeof(float);
-      bf_feature_ids.target = TINYGLTF_TARGET_ARRAY_BUFFER;
-      auto id_bf_feature_ids = model.bufferViews.size();
+      bf_feature_ids.target     = TINYGLTF_TARGET_ARRAY_BUFFER;
+      auto id_bf_feature_ids    = model.bufferViews.size();
       model.bufferViews.push_back(bf_feature_ids);
 
-      acc_feature_ids.bufferView = id_bf_feature_ids;
-      acc_feature_ids.type = TINYGLTF_TYPE_SCALAR;
-      acc_feature_ids.normalized = false;
-      acc_feature_ids.componentType = TINYGLTF_COMPONENT_TYPE_FLOAT;
-      acc_feature_ids.count = inf.vertex_count;
+      acc_feature_ids.bufferView       = id_bf_feature_ids;
+      acc_feature_ids.type             = TINYGLTF_TYPE_SCALAR;
+      acc_feature_ids.normalized       = false;
+      acc_feature_ids.componentType    = TINYGLTF_COMPONENT_TYPE_FLOAT;
+      acc_feature_ids.count            = inf.vertex_count;
+      // This is an int, because tinygltf::Value only knows 'int' (no unsigned etc).
+      int id_acc_feature_ids = model.accessors.size();
       model.accessors.push_back(acc_feature_ids);
-      std::string fid = "_FEATURE_ID_" + std::to_string((int)i);
-      primitive.attributes[fid] = model.accessors.size()-1;  // The index of the accessor for normals
+      std::string fid = "_FEATURE_ID_" + std::to_string(id_acc_feature_ids);
+      primitive.attributes[fid] =
+        model.accessors.size() - 1; // The index of the accessor for normals
 
-      primitive.material = get_material_id(ftype);
-      primitive.mode = TINYGLTF_MODE_TRIANGLES;
+      tinygltf::ExtensionMap primitive_extensions;
+      primitive_extensions["EXT_mesh_features"] = create_ext_mesh_features(1, id_acc_feature_ids, 0);
+
+      primitive.material   = get_material_id(ftype);
+      primitive.mode       = TINYGLTF_MODE_TRIANGLES;
+      primitive.extensions = primitive_extensions;
       mesh.primitives.push_back(primitive);
     }
 
-    buffer.data.resize(index_vec.size()*sizeof(unsigned) + vertex_vec.size()*6*sizeof(float) + feature_id_vec.size()*sizeof(float));
-    memcpy(
-      buffer.data.data(), 
-      (unsigned char*)index_vec.data(), 
-      index_vec.size()*sizeof(unsigned)
-    );
-    memcpy(
-      buffer.data.data() + index_vec.size()*sizeof(unsigned), 
-      (unsigned char*)vertex_vec[0].data(), 
-      vertex_vec.size()*6*sizeof(float)
-    );
-    memcpy(
-      buffer.data.data() + index_vec.size()*sizeof(unsigned) + vertex_vec.size()*6*sizeof(float),
-      (unsigned char*)feature_id_vec.data(),
-      feature_id_vec.size()*sizeof(float)
-    );
+    // EXT_structural_metadata
+    // TODO: for each feature attribute, instead of hardcoded
+    // Schema definition
+    tinygltf::Value::Object prop_objectid;
+    // because tinygltf::Value("somestring") thinks that "somestring" is a bool
+    prop_objectid["description"] = tinygltf::Value((std::string)"objectid property description");
+    prop_objectid["type"] = tinygltf::Value((std::string)"SCALAR");
+    prop_objectid["componentType"] = tinygltf::Value((std::string)"UINT32");
+    prop_objectid["required"] = tinygltf::Value(true);
+    tinygltf::Value::Object prop_bagpandid;
+    prop_bagpandid["description"] = tinygltf::Value((std::string)"bagpandid property description");
+    prop_bagpandid["type"] = tinygltf::Value((std::string)"STRING");
+    tinygltf::Value::Object prop_bouwjaar;
+    prop_bouwjaar["description"] = tinygltf::Value((std::string)"bouwjaar property description");
+    prop_bouwjaar["type"] = tinygltf::Value((std::string)"SCALAR");
+    prop_bouwjaar["componentType"] = tinygltf::Value((std::string)"UINT16");
+    tinygltf::Value::Object building_class_properties;
+    building_class_properties["objectid"] = tinygltf::Value(prop_objectid);
+    building_class_properties["bagpandid"] = tinygltf::Value(prop_bagpandid);
+    building_class_properties["bouwjaar"] = tinygltf::Value(prop_bouwjaar);
+    tinygltf::Value::Object building_class;
+    building_class["name"] = tinygltf::Value((std::string)"Building");
+    building_class["description"] = tinygltf::Value((std::string)"Building class description");
+    building_class["properties"] = tinygltf::Value(building_class_properties);
+    tinygltf::Value::Object classes;
+    classes["building"] = tinygltf::Value(building_class);
+    tinygltf::Value::Object schema;
+    schema["classes"] = tinygltf::Value(classes);
+
+    // Add the property tables for the feature attributes. The property tables
+    // reference bufferviews, which reference the complete array of the values
+    // of one feature attribute (column-based layout).
+    // https://github.com/CesiumGS/glTF/tree/3d-tiles-next/extensions/2.0/Vendor/EXT_structural_metadata#ext_structural_metadata
+    // We need a bufferView for each feature attribute, plus the string offsets
+    // in case of string attributes.
+    tinygltf::BufferView bf_attr_1;
+    tinygltf::BufferView bf_attr_2_offsets;
+    tinygltf::BufferView bf_attr_2;
+    tinygltf::BufferView bf_attr_3;
+    // Everything goes into the same buffer
+    auto byteOffset_attr_1 =
+      byteOffset_feature_id + feature_id_vec.size() * sizeof(float);
+    bf_attr_1.buffer     = 0;
+    bf_attr_1.byteOffset = byteOffset_attr_1;
+    bf_attr_1.byteLength = attr_1_vec.size() * sizeof(unsigned);
+    bf_attr_1.target     = TINYGLTF_TARGET_ARRAY_BUFFER;
+    auto id_bf_attr_1    = model.bufferViews.size();
+    model.bufferViews.push_back(bf_attr_1);
+
+    auto byteOffset_attr_2_offsets =
+      byteOffset_attr_1 + attr_1_vec.size() * sizeof(unsigned);
+    bf_attr_2_offsets.buffer     = 0;
+    bf_attr_2_offsets.byteOffset = byteOffset_attr_2_offsets;
+    bf_attr_2_offsets.byteLength =
+      attr_2_string_offset_vec.size() * sizeof(unsigned long);
+    bf_attr_2_offsets.target  = TINYGLTF_TARGET_ARRAY_BUFFER;
+    auto id_bf_attr_2_offsets = model.bufferViews.size();
+    model.bufferViews.push_back(bf_attr_2_offsets);
+
+    auto byteOffset_attr_2 =
+      byteOffset_attr_2_offsets +
+      attr_2_string_offset_vec.size() * sizeof(unsigned long);
+    bf_attr_2.buffer     = 0;
+    bf_attr_2.byteOffset = byteOffset_attr_2;
+    bf_attr_2.byteLength = attr_2_vec.size() * sizeof(char);
+    bf_attr_2.target     = TINYGLTF_TARGET_ARRAY_BUFFER;
+    auto id_bf_attr_2    = model.bufferViews.size();
+    model.bufferViews.push_back(bf_attr_2);
+
+    auto byteOffset_attr_3 =
+      byteOffset_attr_2 + attr_3_vec.size() * sizeof(unsigned short);
+    bf_attr_3.buffer     = 0;
+    bf_attr_3.byteOffset = byteOffset_attr_3;
+    bf_attr_3.byteLength = attr_3_vec.size() * sizeof(unsigned short);
+    bf_attr_3.target     = TINYGLTF_TARGET_ARRAY_BUFFER;
+    auto id_bf_attr_3    = model.bufferViews.size();
+    model.bufferViews.push_back(bf_attr_3);
+
+    tinygltf::Value::Object prop_tbl_attr_1;
+    prop_tbl_attr_1["values"] = tinygltf::Value((int)id_bf_attr_1);
+    tinygltf::Value::Object prop_tbl_attr_2;
+    prop_tbl_attr_2["values"] = tinygltf::Value((int)id_bf_attr_2);
+    prop_tbl_attr_2["stringOffsets"] = tinygltf::Value((int)id_bf_attr_2_offsets);
+    prop_tbl_attr_2["stringOffsetType"] = tinygltf::Value((std::string)"UINT64");
+    tinygltf::Value::Object prop_tbl_attr_3;
+    prop_tbl_attr_3["values"] = tinygltf::Value((int)id_bf_attr_3);
+    tinygltf::Value::Object properties_building;
+    properties_building["objectid"] = tinygltf::Value(prop_tbl_attr_1);
+    properties_building["bagpandid"] = tinygltf::Value(prop_tbl_attr_2);
+    properties_building["bouwjaar"] = tinygltf::Value(prop_tbl_attr_3);
+    tinygltf::Value::Object property_table_building;
+    property_table_building["class"] = tinygltf::Value((std::string)"building");
+    property_table_building["count"] = tinygltf::Value((int)attr_1_vec.size());
+    property_table_building["name"] = tinygltf::Value((std::string)"building propertyTable name");
+    property_table_building["properties"] = tinygltf::Value(properties_building);
+
+    tinygltf::Value::Object ext_structural_metadata_object;
+    ext_structural_metadata_object["schema"] = tinygltf::Value(schema);
+    tinygltf::Value::Array property_tables;
+    property_tables.emplace_back(property_table_building);
+    ext_structural_metadata_object["proptertyTables"] = tinygltf::Value(property_tables);
+    tinygltf::ExtensionMap root_extensions;
+    root_extensions["EXT_structural_metadata"] = tinygltf::Value(ext_structural_metadata_object);
+
+
+    // Copy contents to the buffer
+    // TODO: we won't actually know upfront how many attribute vectors we have and
+    // what is their type
+    unsigned long total_attr_vec_size =
+      (attr_1_vec.size() * sizeof(unsigned) +
+       attr_3_vec.size() * sizeof(unsigned short) +
+       attr_2_string_offset_vec.size() * sizeof(unsigned long) +
+       attr_2_vec.size() * sizeof(char));
+
+    buffer.data.resize(index_vec.size() * sizeof(unsigned) +
+                       vertex_vec.size() * 6 * sizeof(float) +
+                       feature_id_vec.size() * sizeof(float) +
+                       total_attr_vec_size);
+    auto ptr_end_of_data = buffer.data.data();
+    memcpy(ptr_end_of_data,
+           (unsigned char*)index_vec.data(),
+           index_vec.size() * sizeof(unsigned));
+    ptr_end_of_data += index_vec.size() * sizeof(unsigned);
+    memcpy(ptr_end_of_data,
+           (unsigned char*)vertex_vec[0].data(),
+           vertex_vec.size() * 6 * sizeof(float));
+    ptr_end_of_data += vertex_vec.size() * 6 * sizeof(float);
+    memcpy(ptr_end_of_data,
+           (unsigned char*)feature_id_vec.data(),
+           feature_id_vec.size() * sizeof(float));
+    // TODO: For each attribute vector, we have to copy the contents to the buffer
+    ptr_end_of_data += feature_id_vec.size() * sizeof(float);
+    memcpy(ptr_end_of_data,
+           (unsigned char*)attr_1_vec.data(),
+           attr_1_vec.size() * sizeof(unsigned));
+    ptr_end_of_data += attr_1_vec.size() * sizeof(unsigned);
+    memcpy(ptr_end_of_data,
+           (unsigned char*)attr_2_string_offset_vec.data(),
+           attr_2_string_offset_vec.size() * sizeof(unsigned long));
+    ptr_end_of_data += attr_2_string_offset_vec.size() * sizeof(unsigned long);
+    memcpy(ptr_end_of_data,
+           (unsigned char*)attr_2_vec.data(),
+           attr_2_vec.size() * sizeof(char));
+    ptr_end_of_data += attr_2_vec.size() * sizeof(char);
+    memcpy(ptr_end_of_data,
+           (unsigned char*)attr_3_vec.data(),
+           attr_3_vec.size() * sizeof(unsigned short));
 
     // std::cout << std::endl;
     // for(unsigned i=0; i<index_vec.size(); ++i) {
@@ -396,6 +601,9 @@ namespace geoflow::nodes::basic3d
     model.scenes.push_back(scene);
     model.defaultScene = 0;
     model.buffers.push_back(buffer);
+    model.extensions = root_extensions;
+    model.extensionsUsed.emplace_back("EXT_mesh_features");
+    model.extensionsUsed.emplace_back("EXT_structural_metadata");
 
     // Save it to a file
     fs::path fname = fs::path(manager.substitute_globals(filepath_));

--- a/nodes_gltf.cpp
+++ b/nodes_gltf.cpp
@@ -154,8 +154,7 @@ namespace geoflow::nodes::basic3d
     auto& attributes_inp = poly_input("attributes");
 
     if (metadata_class_name_.empty()) {
-      std::cout << "metadata_class must be provided" << std::endl;
-      return ;
+      throw(gfException("metadata_class must be provided"));
     }
 
     tinygltf::Model model;
@@ -394,8 +393,9 @@ namespace geoflow::nodes::basic3d
       //  It doesn't matter what their specs say, https://github.com/CesiumGS/3d-tiles/tree/main/specification/Metadata#component-type, https://github.com/CesiumGS/3d-tiles/tree/main/specification/Metadata#scalars, https://github.com/CesiumGS/3d-tiles/tree/main/specification/Metadata#strings
       //  that's a lie.
       for (auto& term : attributes_inp.sub_terminals()) {
-        if (!term->get_data_vec()[i].has_value())
+        if (!term->get_data_vec()[i].has_value()) {
           continue;
+        }
         const auto& tname = term->get_name();
         if (term->accepts_type(typeid(bool))) {
           feature_attribute_map[tname].emplace_back(term->get<const bool&>(i));


### PR DESCRIPTION
Follows the 3D Tiles v1.1 specs and implements the [EXT_mesh_features](https://github.com/CesiumGS/glTF/tree/3d-tiles-next/extensions/2.0/Vendor/EXT_mesh_features) and [EXT_structural_metadata](https://github.com/CesiumGS/glTF/tree/3d-tiles-next/extensions/2.0/Vendor/EXT_structural_metadata) extensions.

There are few caveats when using 3D Tiles with Cesium and these are documented in the source code.

beb5a1ee3edfdae7d6f58769375b48c51c1a989c casts incoming attributes to the type that is declared in the parameters.